### PR TITLE
Generate a pkl file to save filenames and classes for reuse

### DIFF
--- a/ImageDataGeneratorCustom.py
+++ b/ImageDataGeneratorCustom.py
@@ -992,7 +992,7 @@ class DirectoryIterator(Iterator):
         # added reference to pickle so once loaded everything should go faster
         results = []
         self.filenames = []
-        self.classes = np.zeros((self.samples*3,), dtype='int32')
+        self.classes = np.zeros((batch_size,), dtype='int32')
         i = 0
 
         print('trying to import pickle file if exists...')


### PR DESCRIPTION
When ImageDataGeneratorCustom is called and a lot of images and classes are used in training (i.e. market 1501 dataset) loading of classes and filenames can be quite long. 

Hear, I save those on a pickle file for use next time deepRanking.py is called, in particular when the triplets generated have not changed.

If triplets are new, then generated 'delete_if_new_data_source.pkl' should be deleted.